### PR TITLE
feat: add server onboarding context

### DIFF
--- a/src/app/[id]/error.tsx
+++ b/src/app/[id]/error.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export default function Error() {
+    return <p>Erro ao carregar os dados.</p>;
+}

--- a/src/app/[id]/layout.tsx
+++ b/src/app/[id]/layout.tsx
@@ -1,17 +1,19 @@
-'use client';
-
 import StepNav from '@/components/StepNav';
-// import { OnboardingProvider } from '@/contexts/OnboardingContext';
+import { OnboardingServerProvider } from '@/contexts/OnboardingServerContext';
+import { getOnboardingLink } from '@/server/onboarding.service';
 import React from 'react';
 
-export default function OnboardingLayout({ children }: { children: React.ReactNode }) {
-  return (
-      // <OnboardingProvider>
-      <>
-          <StepNav />
+interface LayoutProps {
+    children: React.ReactNode;
+    params: { id: string };
+}
 
-          {children}
-      </>
-      // </OnboardingProvider>
-  );
+export default async function OnboardingLayout({ children, params }: LayoutProps) {
+    const data = await getOnboardingLink(params.id);
+    return (
+        <OnboardingServerProvider value={data}>
+            <StepNav />
+            {children}
+        </OnboardingServerProvider>
+    );
 }

--- a/src/app/[id]/loading.tsx
+++ b/src/app/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+    return <p>Carregando...</p>;
+}

--- a/src/app/[id]/organization/page.tsx
+++ b/src/app/[id]/organization/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
+import { useOnboarding } from '@/contexts/OnboardingServerContext';
 import { isValidCnpj, isValidPhoneBR } from '@/utils/validation';
 import { Input } from '@/components/FormsElements/Input';
 import {
@@ -38,15 +39,17 @@ export default function OrganizationPage() {
     const params = useParams<{ id?: string }>();
     const linkCode = (params?.id as string | undefined) ?? undefined;
 
+    const { organization } = useOnboarding();
+
     // --- Estado principal ---
     const [payload, setPayload] = useState<Payload>({
-        document: '',
-        social_name: '',
-        fantasy_name: '',
+        document: organization?.document ?? '',
+        social_name: organization?.social_name ?? '',
+        fantasy_name: organization?.fantasy_name ?? '',
         ddi: '',
-        phone: '',
-        email: '',
-        addresses: [],
+        phone: organization?.phone ?? '',
+        email: organization?.email ?? '',
+        addresses: organization?.addresses ?? [],
     });
 
     const [modalOpen, setModalOpen] = useState(false);

--- a/src/contexts/OnboardingServerContext.tsx
+++ b/src/contexts/OnboardingServerContext.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React, { createContext, useContext } from 'react';
+import { type Address } from '@/components/Modals/ModalAddress';
+
+interface Organization {
+    document: string;
+    social_name: string;
+    fantasy_name: string | null;
+    phone: string;
+    email: string;
+    addresses?: Address[];
+}
+
+export interface OnboardingData {
+    organization?: Organization;
+}
+
+const OnboardingServerContext = createContext<OnboardingData | null>(null);
+
+interface ProviderProps {
+    value: OnboardingData;
+    children: React.ReactNode;
+}
+
+export function OnboardingServerProvider({ value, children }: ProviderProps) {
+    return <OnboardingServerContext.Provider value={value}>{children}</OnboardingServerContext.Provider>;
+}
+
+export function useOnboarding() {
+    const context = useContext(OnboardingServerContext);
+    if (!context) {
+        throw new Error('useOnboarding must be used within an OnboardingServerProvider');
+    }
+    return context;
+}
+

--- a/src/lib/api.server.ts
+++ b/src/lib/api.server.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+import { authApi } from '@/lib/urlApi';
+
+const apiServer = axios.create({
+    baseURL: authApi,
+});
+
+export default apiServer;

--- a/src/lib/urlApi.ts
+++ b/src/lib/urlApi.ts
@@ -1,0 +1,3 @@
+import { env } from '@/lib/env';
+
+export const authApi = env.API_URL;

--- a/src/server/onboarding.service.ts
+++ b/src/server/onboarding.service.ts
@@ -1,0 +1,18 @@
+import api from '@/lib/api.server';
+import { cache } from 'react';
+
+interface OnboardingLink {
+    organization?: {
+        document: string;
+        social_name: string;
+        fantasy_name: string | null;
+        phone: string;
+        email: string;
+        addresses?: any[];
+    };
+}
+
+export const getOnboardingLink = cache(async (id: string): Promise<OnboardingLink> => {
+    const { data } = await api.get(`/onboarding/${id}`);
+    return data as OnboardingLink;
+});


### PR DESCRIPTION
## Summary
- fetch onboarding link on server layout and share via context
- add server-only API client and service with caching
- initialize organization form from shared onboarding data

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_68a637d4efdc8329924caab4d745fe16