### PR TITLE
feat: adjust participant modal level flow

### DIFF
--- a/src/app/[id]/partners/components/MemberTree.tsx
+++ b/src/app/[id]/partners/components/MemberTree.tsx
@@ -35,7 +35,7 @@ export interface MemberNode {
 type RowProps = {
     member: MemberNode;
     onEdit: (member: MemberNode) => void;
-    onAddParticipant: (parentId: string) => void;
+    onAddParticipant: (parentId: string, level: number) => void;
 };
 
 const formatPct = (p?: string | number) => {
@@ -75,13 +75,13 @@ function MemberRow({member, onEdit, onAddParticipant}: RowProps) {
                     iconOnly
                 />
 
-                {member.level === 1 && (
+                {(member.level === 1 || member.level === 2) && (
                     <Button
                         type="button"
                         color="gray"
                         size="sm"
                         iconLeft={<PlusIcon className="w-4 h-4 stroke-black"/>}
-                        onClick={() => onAddParticipant(member.id)}
+                        onClick={() => onAddParticipant(member.id, member.level)}
                     >
                         Participante
                     </Button>
@@ -94,7 +94,7 @@ function MemberRow({member, onEdit, onAddParticipant}: RowProps) {
 type TreeProps = {
     members: MemberNode[];
     onEdit: (member: MemberNode) => void;
-    onAddParticipant: (parentId: string) => void;
+    onAddParticipant: (parentId: string, level: number) => void;
 };
 
 export default function MemberTree({members, onEdit, onAddParticipant}: TreeProps) {

--- a/src/app/[id]/partners/components/Modals/ModalParticipants/FormPF.tsx
+++ b/src/app/[id]/partners/components/Modals/ModalParticipants/FormPF.tsx
@@ -73,9 +73,11 @@ type FormPFProps = {
     initialValues?: any;         // pode conter id
     readOnlyType?: boolean;
     onSaved?: (saved: MemberNode) => void; // pai atualiza/fecha se quiser
+    level?: number;
+    parentBusinessId?: string;
 };
 
-export default function FormPF({ clientId, initialValues, readOnlyType: _readOnlyType, onSaved }: FormPFProps) {
+export default function FormPF({ clientId, initialValues, readOnlyType: _readOnlyType, onSaved, level, parentBusinessId }: FormPFProps) {
 
     const [payload, setPayload] = React.useState({
         id: initialValues?.id ?? '',
@@ -91,14 +93,17 @@ export default function FormPF({ clientId, initialValues, readOnlyType: _readOnl
     const [errors, setErrors] = React.useState<Record<string, string>>({});
     const [loading, setLoading] = React.useState(false);
 
+    const resolvedLevel = level ?? 1;
+    const resolvedParent = parentBusinessId ?? null;
+
     const buildMemberNode = (values: any): MemberNode => ({
         id: values.id || '',
-        level: 1,
+        level: resolvedLevel,
         member_type: 'PERSON',
         associate: false,
         details: { id: '', name: values.name, document: values.document },
         participation_percentage: values.percentage,
-        parent_business_id: null,
+        parent_business_id: resolvedParent,
         required_documents: [],
         submitted_documents: [],
         type: values.representative ? 'LEGAL_REPRESENTATIVE' : null,
@@ -123,6 +128,8 @@ export default function FormPF({ clientId, initialValues, readOnlyType: _readOnl
                     details: { name: values.name, document: values.document },
                     participation_percentage: values.percentage,
                     type: values.representative ? 'LEGAL_REPRESENTATIVE' : null,
+                    level: resolvedLevel,
+                    parent_business_id: resolvedParent,
                     // inclua addresses se o backend espera aqui:
                     addresses: values.addresses,
                     occupation: values.occupation,
@@ -145,7 +152,7 @@ export default function FormPF({ clientId, initialValues, readOnlyType: _readOnl
              //   await api.post(`${authApi}/v1/client/members/${clientId}`, upsertPayload);
             }
             // notifica o pai com um MemberNode (útil para atualizar a lista)
-            // onSaved?.(buildMemberNode(values));
+            onSaved?.(buildMemberNode(values));
             setLoading(false);
         } catch (err: any) {
             setLoading(false);

--- a/src/app/[id]/partners/components/Modals/ModalParticipants/FormPJ.tsx
+++ b/src/app/[id]/partners/components/Modals/ModalParticipants/FormPJ.tsx
@@ -2,33 +2,93 @@
 
 import * as React from 'react';
 import { Button } from '@/components/Button/Button';
+import api from '@/lib/axios';
+import { authApi } from '@/lib/urlApi';
+import { MemberNode } from '@/types/Members';
 
-export default function FormPJ({
-  onSubmit,
-  initialValues,
-  readOnlyType: _readOnlyType,
-}: {
-  onSubmit: (values: any) => void;
+type FormPJProps = {
+  clientId: string;
   initialValues?: any;
   readOnlyType?: boolean;
-}) {
-  const [payload, setPayload] = React.useState({
-    corporate_name: '',
-    cnpj: '',
-    email: '',
-    phone: '',
-    percentage: '',
-    ...(initialValues || {}),
-  });
-  const [pending, _startTransition] = React.useTransition();
+  onSaved?: (saved: MemberNode) => void;
+  level?: number;
+  parentBusinessId?: string;
+};
 
-  const handleSubmit = (e: React.FormEvent) => {
+export default function FormPJ({
+  clientId,
+  initialValues,
+  readOnlyType: _readOnlyType,
+  onSaved,
+  level,
+  parentBusinessId,
+}: FormPJProps) {
+  const [payload, setPayload] = React.useState({
+    id: initialValues?.id ?? '',
+    corporate_name: initialValues?.corporate_name ?? '',
+    cnpj: initialValues?.cnpj ?? '',
+    email: initialValues?.email ?? '',
+    phone: initialValues?.phone ?? '',
+    percentage: initialValues?.percentage ?? '',
+  });
+  const [errors, setErrors] = React.useState<Record<string, string>>({});
+  const [loading, setLoading] = React.useState(false);
+
+  const resolvedLevel = level ?? 1;
+  const resolvedParent = parentBusinessId ?? null;
+
+  const buildMemberNode = (values: any): MemberNode => ({
+    id: values.id || '',
+    level: resolvedLevel,
+    member_type: 'BUSINESS',
+    associate: false,
+    details: { id: '', name: values.corporate_name, document: values.cnpj },
+    participation_percentage: values.percentage,
+    parent_business_id: resolvedParent,
+    required_documents: [],
+    submitted_documents: [],
+    type: null,
+    members: [],
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit(payload);
+    setLoading(true);
+    setErrors({});
+
+    const values = payload;
+    const isEdit = Boolean(values.id);
+
+    const upsertPayload = {
+      member: {
+        id: values.id || undefined,
+        member_type: 'BUSINESS',
+        details: { name: values.corporate_name, document: values.cnpj },
+        participation_percentage: values.percentage,
+        email: values.email || undefined,
+        phone: values.phone || undefined,
+        level: resolvedLevel,
+        parent_business_id: resolvedParent,
+      },
+    };
+
+    try {
+      if (isEdit) {
+        await api.put(`${authApi}/v1/client/${clientId}/members/${values.id}`, upsertPayload);
+      } else {
+        // await api.post(`${authApi}/v1/client/members/${clientId}`, upsertPayload);
+      }
+
+      onSaved?.(buildMemberNode(values));
+      setLoading(false);
+    } catch (err: any) {
+      setLoading(false);
+      setErrors({ __global: err?.message || 'Erro ao salvar.' });
+    }
   };
 
   return (
-    <form className="space-y-4" onSubmit={handleSubmit}>
+    <form className="space-y-4" onSubmit={handleSubmit} noValidate>
       <input
         className="input"
         placeholder="Razão Social"
@@ -56,11 +116,12 @@ export default function FormPJ({
       <input
         className="input"
         placeholder="Percentual de Participação"
-        value={payload.percentage || ''}
+        value={payload.percentage}
         onChange={(e) => setPayload((p) => ({ ...p, percentage: e.target.value }))}
       />
-      <Button type="submit" color="primary" fullWidth disabled={pending}>
-        {pending ? 'Salvando...' : 'Salvar (PJ)'}
+      {errors.__global && <p className="text-red text-sm">{errors.__global}</p>}
+      <Button type="submit" color="primary" fullWidth disabled={loading}>
+        {loading ? 'Salvando...' : 'Salvar (PJ)'}
       </Button>
     </form>
   );

--- a/src/app/[id]/partners/components/Modals/ModalParticipants/index.tsx
+++ b/src/app/[id]/partners/components/Modals/ModalParticipants/index.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import React from 'react';
-import {ArrowLeftIcon, BuildingOffice2Icon, UserIcon} from '@heroicons/react/24/outline';
+import {ArrowLeftIcon} from '@heroicons/react/24/outline';
 import FormPF from './FormPF';
 import FormPJ from './FormPJ';
 import {MemberNode} from '@/types/Members';
@@ -15,6 +15,8 @@ export type ModalPaticipantsProps = {
   onClose: () => void;
   onSaved?: (saved: MemberNode) => void;
   clientId: string; // <- adicione isso
+  targetLevel: number;
+  parentBusinessId?: string;
 };
 
 function mapMemberToPF(data?: Partial<MemberNode>) {
@@ -44,13 +46,15 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
                                                              onClose,
                                                              onSaved,
                                                              clientId,
+                                                             targetLevel,
+                                                             parentBusinessId,
                                                            }) => {
   const activeType: 'PERSON' | 'BUSINESS' = (initialData?.member_type as any) ?? 'PERSON';
   const [activeTab, setActiveTab] = React.useState<'PERSON' | 'BUSINESS'>(activeType);
 
   const onTabClick = (tab: 'PERSON' | 'BUSINESS') => (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    if (lockType) return;
+    if (lockType || mode === 'edit') return;
     setActiveTab(tab);
   };
 
@@ -89,9 +93,28 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
             <div className="w-full max-w-xl mx-auto">
               {mode === 'create' && (
                   <>
+                    <div className="flex items-center justify-center gap-2 pt-4 pb-6">
+                      <a
+                          href="#"
+                          onClick={onTabClick('PERSON')}
+                          className={`px-3 py-1.5 rounded-full text-sm ${isActive('PERSON') ? 'bg-black text-white' : 'bg-neutral-100 text-neutral-700'}`}
+                      >
+                        Pessoa Física
+                      </a>
+                      <a
+                          href="#"
+                          onClick={onTabClick('BUSINESS')}
+                          className={`px-3 py-1.5 rounded-full text-sm ${isActive('BUSINESS') ? 'bg-black text-white' : 'bg-neutral-100 text-neutral-700'}`}
+                      >
+                        Pessoa Jurídica
+                      </a>
+                    </div>
+
                     <div className={isActive('PERSON') ? '' : 'hidden'}>
                       <FormPF
                           clientId={clientId}
+                          level={targetLevel}
+                          parentBusinessId={parentBusinessId}
                           initialValues={undefined}
                           onSaved={handleSavedFromChild} // <- o filho chama quando terminar
                       />
@@ -99,6 +122,8 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
                     <div className={isActive('BUSINESS') ? '' : 'hidden'}>
                       <FormPJ
                           clientId={clientId}
+                          level={targetLevel}
+                          parentBusinessId={parentBusinessId}
                           initialValues={undefined}
                           onSaved={handleSavedFromChild}
                       />
@@ -109,6 +134,8 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
               {mode === 'edit' && activeType === 'PERSON' && (
                   <FormPF
                       clientId={clientId}
+                      level={initialData?.level}
+                      parentBusinessId={initialData?.parent_business_id ?? undefined}
                       initialValues={mapMemberToPF(initialData)}
                       readOnlyType
                       onSaved={handleSavedFromChild}
@@ -118,6 +145,8 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
               {mode === 'edit' && activeType === 'BUSINESS' && (
                   <FormPJ
                       clientId={clientId}
+                      level={initialData?.level}
+                      parentBusinessId={initialData?.parent_business_id ?? undefined}
                       initialValues={mapMemberToPJ(initialData)}
                       readOnlyType
                       onSaved={handleSavedFromChild}


### PR DESCRIPTION
## Summary
- propagate node level when adding participants and enable button on level 1 and 2
- support level/parent info in participant modal with PF/PJ tabs
- include level and parent_business_id in PF/PJ forms and update state handling

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build` *(fails: Failed to fetch Google Fonts and missing module ./globals.css)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find various modules/types)*

------
https://chatgpt.com/codex/tasks/task_b_68aa2ec971f88329a4f2a73508bfa661