### PR TITLE
limit participant percentage by level

### DIFF
--- a/src/app/[id]/partners/components/Modals/ModalParticipants/index.tsx
+++ b/src/app/[id]/partners/components/Modals/ModalParticipants/index.tsx
@@ -16,6 +16,7 @@ export type ModalPaticipantsProps = {
   clientId: string; // <- adicione isso
   targetLevel: number;
   parentBusinessId?: string;
+  maxAllowedPercentage: number; // NOVO
 };
 
 const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
@@ -28,6 +29,7 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
   clientId,
   targetLevel,
   parentBusinessId,
+  maxAllowedPercentage,
 }) => {
   const handleSavedFromChild = (saved: MemberNode) => {
     onSaved?.(saved);
@@ -79,6 +81,7 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
                 parentBusinessId={parentBusinessId}
                 mode="create"
                 readOnlyType={lockType}
+                maxAllowedPercentage={maxAllowedPercentage}
                 onSaved={handleSavedFromChild}
               />
             )}
@@ -91,6 +94,7 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
                 mode="edit"
                 readOnlyType
                 initialValues={initialValues}
+                maxAllowedPercentage={maxAllowedPercentage}
                 onSaved={handleSavedFromChild}
               />
             )}


### PR DESCRIPTION
## Summary
- enforce level-based participation limits with new helper utilities
- propagate and use max allowed percentage in participant modals
- validate and display available percentage in participant form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68ab1cf862808329ad9e697fc5b4ef97