### PR TITLE
feat: handle required participant docs

### DIFF
--- a/src/app/[id]/partners/PartnersPageClient.tsx
+++ b/src/app/[id]/partners/PartnersPageClient.tsx
@@ -348,6 +348,7 @@ export default function PartnersPageClient({link}: { link: OnboardingLinkApi }) 
                 lockType={modalMode === 'edit'}
                 targetLevel={targetLevel ?? 1}
                 parentBusinessId={targetParentId ?? undefined}
+                requiredDocuments={(link as any)?.required_documents}
                 onClose={() => {
                     setOpenParticipant(false);
                     setEditingMember(null);

--- a/src/app/[id]/partners/components/Modals/ModalParticipants/index.tsx
+++ b/src/app/[id]/partners/components/Modals/ModalParticipants/index.tsx
@@ -17,6 +17,10 @@ export type ModalPaticipantsProps = {
   targetLevel: number;
   parentBusinessId?: string;
   maxAllowedPercentage: number; // NOVO
+  requiredDocuments?: {
+    business?: Record<string, Array<{ id: string }>>;
+    person?: Record<string, Array<{ id: string }>>;
+  };
 };
 
 const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
@@ -30,6 +34,7 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
   targetLevel,
   parentBusinessId,
   maxAllowedPercentage,
+  requiredDocuments,
 }) => {
   const handleSavedFromChild = (saved: MemberNode) => {
     onSaved?.(saved);
@@ -48,6 +53,7 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
         member_type: initialData.member_type as 'PERSON' | 'BUSINESS',
         level: initialData.level,
         parent_business_id: initialData.parent_business_id ?? null,
+        submitted_documents: initialData.submitted_documents ?? [],
       }
     : undefined;
 
@@ -82,6 +88,7 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
                 mode="create"
                 readOnlyType={lockType}
                 maxAllowedPercentage={maxAllowedPercentage}
+                requiredDocuments={requiredDocuments}
                 onSaved={handleSavedFromChild}
               />
             )}
@@ -95,6 +102,7 @@ const ModalPaticipants: React.FC<ModalPaticipantsProps> = ({
                 readOnlyType
                 initialValues={initialValues}
                 maxAllowedPercentage={maxAllowedPercentage}
+                requiredDocuments={requiredDocuments}
                 onSaved={handleSavedFromChild}
               />
             )}


### PR DESCRIPTION
## Summary
- forward required documents from onboarding link to participant form
- render dynamic document uploads and submit paths with participants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npx tsc --noEmit` *(fails: missing modules and type errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ab3712fda883298ac5dc632e1b25df